### PR TITLE
Send email job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 secrets.toml
+.idea
+**/__pycache__/
+venv

--- a/app.py
+++ b/app.py
@@ -1,11 +1,14 @@
 import streamlit as st
+import schedule
+import time
 from scripts.prediction import show_prediction
 from scripts.about import show_about
 from scripts.metar import show_metar
 from scripts.taf import show_taf
 from scripts.cloud import show_cloud
 from scripts.solar import visualize_csv
-from scripts.location import show_location_predictions 
+from scripts.location import show_location_predictions
+from scripts.send_email_job import send_email_job
 
 st.set_page_config(layout="wide", page_title="🌤️ Energy Prediction Dashboard")
 
@@ -27,3 +30,11 @@ elif page == "Solar Parameters":
     visualize_csv("csv/solar_2025.csv")
 elif page == "Location":
     show_location_predictions()
+
+schedule.every().day.at("7:01").do(send_email_job)
+schedule.every().day.at("11:01").do(send_email_job)
+schedule.every().day.at("15:01").do(send_email_job)
+
+while True:
+    schedule.run_pending()
+    time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy==1.26.4
 python-dateutil==2.9.0  
 pytz==2024.1 
 python-dotenv==1.0.1
+schedule==1.2.2

--- a/scripts/send_email_job.py
+++ b/scripts/send_email_job.py
@@ -1,0 +1,47 @@
+import streamlit as st
+import pandas as pd
+from scripts.weather import extract_weather_features_for_hours
+from scripts.model import load_model, predict_power
+from io import BytesIO
+from datetime import datetime
+from scripts.csv_email import send_email
+
+
+def send_email_job():
+    """
+    Sends email containing the upcoming 4-hour prediction.
+
+    Returns
+    -------
+    None
+
+    See Also
+    --------
+    This method is intended to be used as a scheduled job.
+    Using schedule <https://github.com/dbader/schedule> package.
+    """
+    model, expected_features = load_model()
+    features_list = extract_weather_features_for_hours()
+
+    if not features_list:
+        return
+
+    predictions = []
+    for idx, features in enumerate(features_list, start=1):
+        features_df = pd.DataFrame([features])
+        prediction = predict_power(model, expected_features, features_df)
+        predictions.append({
+            'Validity': f"{features['timehr']:02d}00 - {(features['timehr'] + 1) % 24:02d}00",
+            'Predicted Power (kW)': round(prediction, 2),
+            **features
+        })
+
+    combined_df = pd.DataFrame(predictions)
+    combined_df = combined_df.drop(columns=['Hour'], errors='ignore')
+
+    # Convert DataFrame to CSV and store in memory
+    csv_buffer = BytesIO()
+    filename = datetime.now().strftime("%Y-%m-%d") + "_4hr_Energy_Predictions.csv"
+    combined_df.to_csv(csv_buffer, index=False)
+    csv_buffer.seek(0)
+    send_email(st.secrets["EMAIL_TO"], csv_buffer, filename)


### PR DESCRIPTION
# Feature Addition

CLOSES #9

## Summary

Adds a scheduled job using the schedule package for python.

## Rationale

Prior this email export was sent manually, which is time consuming and inconvenient at times when it must be pressed.

## Design Documentation

[schedule](https://schedule.readthedocs.io/en/stable/)

## Changes

- Adds a scheduled job for sending email export
- Updates gitignore

## Impact

Will need to be tested to verify job is sent at correct time.

## Testing

N/A

## Screenshots/Video

N/A

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A